### PR TITLE
Fix correlation dispatch and update TxToGene test API

### DIFF
--- a/R/correlation-methods.R
+++ b/R/correlation-methods.R
@@ -87,7 +87,7 @@ formals(`correlation,numeric,numeric`)[["method"]] <- # nolint
 
 ## Updated 2021-02-03.
 `correlation,matrix,missing` <- # nolint
-    function(x, method, y = NULL) {
+    function(x, y = NULL, method) {
         assert(!anyNA(x))
         method <- match.arg(method)
         alert(sprintf(

--- a/man/correlation.Rd
+++ b/man/correlation.Rd
@@ -15,7 +15,7 @@ correlation(x, y, ...)
 
 \S4method{correlation}{Matrix,Matrix}(x, y, method = c("pearson", "kendall", "spearman"))
 
-\S4method{correlation}{Matrix,missingOrNULL}(x, method = c("pearson", "kendall", "spearman"), y = NULL)
+\S4method{correlation}{Matrix,missingOrNULL}(x, y = NULL, method = c("pearson", "kendall", "spearman"))
 
 \S4method{correlation}{SummarizedExperiment,SummarizedExperiment}(x, y, method = c("pearson", "kendall", "spearman"), i = 1L)
 
@@ -29,7 +29,7 @@ correlation(x, y, ...)
 
 \S4method{correlation}{matrix,matrix}(x, y, method = c("pearson", "kendall", "spearman"))
 
-\S4method{correlation}{matrix,missingOrNULL}(x, method = c("pearson", "kendall", "spearman"), y = NULL)
+\S4method{correlation}{matrix,missingOrNULL}(x, y = NULL, method = c("pearson", "kendall", "spearman"))
 
 \S4method{correlation}{numeric,numeric}(x, y, method = c("pearson", "kendall", "spearman"))
 }

--- a/tests/testthat/test-convertTranscriptsToGenes.R
+++ b/tests/testthat/test-convertTranscriptsToGenes.R
@@ -3,12 +3,16 @@
 skip_if_not(hasInternet())
 
 ## NOTE Consider using a presaved object, to speed up tests.
-tx2gene <- AcidGenomes::makeTxToGeneFromEnsembl( # nolint
+## makeTxToGeneFromEnsembl was removed in AcidGenomes 0.8.x; build TxToGene
+## via makeGRangesFromEnsembl() at the transcripts level instead.
+gr <- AcidGenomes::makeGRangesFromEnsembl(
     organism = "Homo sapiens",
+    level = "transcripts",
     genomeBuild = "GRCh38",
     release = 87L,
     ignoreVersion = TRUE
 )
+tx2gene <- AcidGenomes::TxToGene(gr)
 
 test_that("character", {
     ## Ensure that function supports remapping of column names.


### PR DESCRIPTION
## Fixes\n\n**correlation,matrix,missing**: argument `y` was positioned after `method` in the method body, mismatching the generic `(x, y, ...)`. Caused `correlation(x)` to error with 'argument y is missing'. Fixed by reordering to `function(x, y = NULL, method)`.\n\n**test-convertTranscriptsToGenes**: `AcidGenomes::makeTxToGeneFromEnsembl()` was removed in AcidGenomes 0.8.x. Updated to the current API: `makeGRangesFromEnsembl(level='transcripts')` then `TxToGene()`.