### PR TITLE
Fix correlation,matrix,missing: explicit method default

### DIFF
--- a/R/correlation-methods.R
+++ b/R/correlation-methods.R
@@ -87,7 +87,7 @@ formals(`correlation,numeric,numeric`)[["method"]] <- # nolint
 
 ## Updated 2021-02-03.
 `correlation,matrix,missing` <- # nolint
-    function(x, y = NULL, method) {
+    function(x, y = NULL, method = .method) {
         assert(!anyNA(x))
         method <- match.arg(method)
         alert(sprintf(


### PR DESCRIPTION
Give `method` an explicit default (`method = .method`) in the function signature so `function_argument_linter` does not flag it. The `formals()` override continues to set the actual default at load time.